### PR TITLE
Allwinner: Add H3/H5 TVE overlays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,14 @@ DTBOS := \
   overlays/allwinner/sun50i-a64-pine64-wifi-bt.dtbo \
   overlays/allwinner/sun50i-a64-spdif.dtbo \
   overlays/allwinner/sun50i-h5-spdif.dtbo \
+  overlays/allwinner/sun50i-h5-tve.dtbo \
   overlays/allwinner/sun50i-h6-ir.dtbo \
   overlays/allwinner/sun50i-h6-spdif.dtbo \
   overlays/allwinner/sun8i-h2-plus-bpi-m2-zero-ethernet.dtbo \
   overlays/allwinner/sun8i-h2-plus-ir.dtbo \
   overlays/allwinner/sun8i-h2-plus-spdif.dtbo \
-  overlays/allwinner/sun8i-h3-spdif.dtbo
+  overlays/allwinner/sun8i-h3-spdif.dtbo \
+  overlays/allwinner/sun8i-h3-tve.dtbo
 
 all: $(DTBOS)
 

--- a/overlays/allwinner/sun50i-h5-tve.dts
+++ b/overlays/allwinner/sun50i-h5-tve.dts
@@ -1,0 +1,12 @@
+//SPDX-License-Identifier: GPL-2.0+ or MIT
+//Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun50i-h5";
+};
+
+&tve {
+	status = "okay";
+};

--- a/overlays/allwinner/sun8i-h3-tve.dts
+++ b/overlays/allwinner/sun8i-h3-tve.dts
@@ -1,0 +1,12 @@
+//SPDX-License-Identifier: GPL-2.0+ or MIT
+//Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun8i-h3";
+};
+
+&tve {
+	status = "okay";
+};


### PR DESCRIPTION
This PR adds TVE (CVBS) overlays for Allwinner H3 and H5.